### PR TITLE
Add CLI for processing SUMO outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The project follows a relaxed development pipeline by using issues, pull request
 
 ### Preparing simulation data (CSV.GZ files)
 
-The UI reads pre-processed `.csv.gz` files from `simulation/scenarios/<area>/<scenario>/`. These are produced from raw SUMO output by running a simulation via `run_simulation()` in `utils/helpers.py`, or by manually calling `aggregate_outputs()` on an existing SUMO output folder. The full pipeline is:
+The UI reads pre-processed `.csv.gz` files from `simulation/scenarios/<area>/<scenario>/`. These are produced from raw SUMO output by running a simulation via `run_simulation()` in `utils/helpers.py`, or by manually calling `aggregate_outputs()` on an existing SUMO output folder (`utils/aggregate_outputs_cli.py`). The full pipeline is:
 
 #### 1. Run the SUMO simulation
 
@@ -76,9 +76,11 @@ This function:
    - Parses the XML into a pandas DataFrame.
    - Merges with the network geometry to attach `Longitude`, `Latitude`, and `Edge` to each record.
    - Saves the result as a gzip-compressed CSV (`.csv.gz`) alongside the original XML.
-   - Deletes the raw XML file.
+   - Deletes the raw XML file if `erase_xml=True`.
 
 The resulting `.csv.gz` files have **1-second time resolution** (`Simulation timestep` column in seconds) and are what the UI loads at runtime. The UI then re-bins the data into the user-selected temporal resolution (1 min, 15 min, 30 min, or 60 min) on the fly.
+
+Script `utils/aggregate_outputs_cli.py` can be used to produce `csv` and `csv.gz` files through command line from the existing SUMO outputs.
 
 #### Expected folder structure
 

--- a/utils/aggregate_outputs_cli.py
+++ b/utils/aggregate_outputs_cli.py
@@ -1,0 +1,31 @@
+import argparse
+
+from utils.helpers import aggregate_outputs
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Convert SUMO XML outputs to compressed CSV files.")
+    parser.add_argument(
+        "--sumo-net-path",
+        type=str,
+        default="simulation/scenarios/vihdintie/vihdintie_trimmed.net.xml",
+        help="Path to the SUMO network file."
+    )
+    parser.add_argument(
+        "--sumo-xml-folder",
+        type=str,
+        default="simulation/scenarios/vihdintie/regular_autumn_weekday/baseline",
+        help="Folder containing SUMO XML output files."
+    )
+    parser.add_argument(
+        "--erase-xml",
+        action="store_true",
+        help="Erase the original XML files after conversion to CSV."
+    )
+    return parser.parse_args()
+
+def main() -> None:
+    args = parse_args()
+    aggregate_outputs(args.sumo_net_path, args.sumo_xml_folder, erase_xml=args.erase_xml)
+
+if __name__ == "__main__":
+    main()

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -5,6 +5,7 @@ import os
 import glob
 import plotly.express as px
 import utils.constants as uc
+# from . import constants as uc
 import sys
 import sumolib
 import random
@@ -789,42 +790,37 @@ def _modify_config(
 def aggregate_outputs(
     net_path="simulation/scenarios/kamppi/baseline_net.xml",
     full_output_folder="simulation/scenarios/kamppi/regular_summer_weekday/optimized_equal",
+    erase_xml=False,
 ):
     # Convert the output files of raw xml to gzipped csv
     net_df = _parse_net_xml(net_path)
-    xml_output_files = glob.glob(f"{full_output_folder}/*.xml*")
+    xml_output_files = glob.glob(f"{full_output_folder}/*.xml")
+    print(f"Found {len(xml_output_files)} XML output files in {full_output_folder}.")
     for filename in xml_output_files:
+        print(f"Processing {filename}...")
         file_without_extension = filename.split(".")[0]
-        with open(filename, "rb") as f_in:
-            with gzip.open(f"{filename}.gz", "wb") as f_out:
-                shutil.copyfileobj(f_in, f_out)
-                os.remove(f_in)
-                # if "lane_noise" in f_out:
-                #     lane_noise = parse_lane_noise_xml(f_out, net_df)
-                #     lane_noise.to_csv(
-                #         f"{file_without_extension}.csv.gz",
-                #         compression="gzip",
-                #     )
-                if "edge_noise" in filename:
-                    edge_noise = _parse_edge_noise_xml(f_out, net_df)
-                    # print(edge_noise.head())
-                    edge_noise.to_csv(
-                        f"{file_without_extension}.csv.gz",
-                        compression="gzip",
-                    )
-                elif "trip" in filename:
-                    trip_info = _parse_trip_output_xml(f_out)
-                    trip_info.to_csv(
-                        f"{file_without_extension}.csv.gz",
-                        compression="gzip",
-                    )
-                elif "emission" in filename:
-                    emissions = _parse_emissions_xml(f_out, net_df)
-                    emissions.to_csv(
-                        f"{file_without_extension}.csv.gz",
-                        compression="zip",
-                    )
-                os.remove(f_out)
+
+        if "edge_noise" in filename:
+            result = _parse_edge_noise_xml(filename, net_df)
+        elif "trip" in filename:
+            result = _parse_trip_output_xml(filename)
+        elif "emission" in filename:
+            result = _parse_emissions_xml(filename, net_df)
+        else:
+            continue
+
+        output_name = os.path.splitext(os.path.basename(filename))[0]
+        csv_path = os.path.join(full_output_folder, f"{output_name}.csv")
+
+        result.to_csv(csv_path, index=False)
+        result.to_csv(
+            f"{csv_path}.gz",
+            index=False,
+            compression="gzip",
+        )
+
+        if erase_xml:
+            os.remove(filename)
 
 
 # Simulate


### PR DESCRIPTION
Fixed #43 

- `utils.aggregate_outputs_cli` is a CLI wrapper for processing existing SUMO xml outputs without running SUMO simulation by UI helper code.
- new option `--erase-xml` added to switch on and off the deletion of SUMO xml files after processing.
- `utils` is a module now.
- documentation updated.