### PR TITLE
Add color grid cells for emission visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This function:
 
 The resulting `.csv.gz` files have **1-second time resolution** (`Simulation timestep` column in seconds) and are what the UI loads at runtime. The UI then re-bins the data into the user-selected temporal resolution (1 min, 15 min, 30 min, or 60 min) on the fly.
 
-Script `utils/aggregate_outputs_cli.py` can be used to produce `csv` and `csv.gz` files through command line from the existing SUMO outputs.
+Script `utils/aggregate_outputs_cli.py` can be used to produce `csv` and `csv.gz` files through command line from the existing SUMO outputs. In this case, files will be read from and write to `--sumo-xml-folder` path.
 
 #### Expected folder structure
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ AioSUT is a RCF-funded project about developing an AI-based optimization tool fo
 
 ## User Guide
 
+Run the visualization with the existing edge-based air-quality view using
+`python -m new_app --edge` (also the default), or with polygon cell results from
+`emission_results_cells.csv` and `AQ_grid.geojson` using `python -m new_app --cell`.
+
 1. Install the following pre-requisites:
    - **Python**: Download the latest Python from [Python's official website](https://www.python.org/downloads/). Pip is recommended as the package installer.
    - **Simulation for Urban MObility (SUMO)**: Follow the installation instructions from [SUMO's official website.](https://www.eclipse.org/sumo/)
@@ -49,7 +53,7 @@ The UI reads pre-processed `.csv.gz` files from `simulation/scenarios/<area>/<sc
 
 SUMO must be installed and the `SUMO_HOME` environment variable must point to its installation directory. The simulation is run for 3600 seconds (1 hour) at 1-second time resolution. It produces two raw XML output files in the scenario output folder:
 
-- `emission_results.xml` — per-vehicle, per-second emissions (CO₂, CO, HC, NOx, PMx), speed, noise, fuel/electricity consumption, and vehicle class.
+- `emission_results.xml` — per-vehicle, per-second emissions (CO₂‚, CO, HC, NOx, PMx), speed, noise, fuel/electricity consumption, and vehicle class.
 - `trip_results.xml` — per-trip travel time, lost time, and route information.
 - `edge_noise_results.xml` — per-edge noise levels aggregated by the `add.xml` additional file.
 

--- a/docs/devnotes.md
+++ b/docs/devnotes.md
@@ -1,0 +1,45 @@
+# Milestones
+
+M1. Visualize the outputs (baseline/optimized) for Couscous model (denoted as `vihdintie_small`).
+
+M2. Launch the model for AIOSUT area (denoted as `vihdintie_large`).
+
+M3. Train the model for different scenarios (season/time of week/demand/priorities).
+
+# M1 tasks
+
+## Notes
+
+- Traffic and Air Quality tabs use the data from `.csv.gz` files which are raw SUMO outputs on emissions, trips and noise preprocessed with a function `aggregate_outputs()` from module `utils/helpers`. Preprocessing also extract edge/lane coordinates from `baseline.net.xml` and bakes them into `.csv.gz` files. 
+- Current tool uses the following xml files from SUMO outputs: edge noise, trip output, emissions. To get edge noise from SUMO, one needs to specify `edgeData` in `add.xml` (see the example in `dev_aiosut_ui` repo). Trip and emission outputs are specified in config.sumocfg.
+- `trip_results.csv` contains aggregated information per trip on lost time, travel time, mobility mode and emissions, obtained from tripinfo.xml.
+- `emissions_results.csv` contains per-step emissions, noise and speed data, including edge location and name.
+- Summary tab also pulls data from  `.csv.gz` files using `get_data()` function. This function aggregates the observables for the whole simulation period. 
+
+## Questions to discuss
+- [ ] How to visualize priorities of objectives? How about dropdown list Traffic 0.4, AQ 0.3, Liv  0.3?
+- [ ] What is baseline? 
+- [x] What do we want to show in summary? Now it is mobility mode distribution, average travel time, respirable particles (?). According to Linsen's slides, it may be driving percentage (baseline vs optimized), average speed (baseline vs optimized), air quality (PM2.5 / BC / Ntot), normalized livability. 
+- [x] The tool assumes that mobility modes are represented by two types of cars: fuel and electric. Which mobility modes are supported now in the model (and which do we want to show)? Pedestrians, bicycles, private cars, buses. No different types of cars (?).
+- [x] Which observables to visualize for livability? Relocation rate, demographics of the agents. Changing livability values (?). 
+- [ ] Does each combination of priorities already has corresponding SUMO output data (namely, `emission_results.xml`, `trip_results.xml`,`edge_noise_results.xml`)? 
+  
+## Description of the code base (devnotes)
+- `callbacks.py`, `show_graphs` - main plotting logic, uses `utils.helpers.get_data()`, which read the data from `csv.gz` files.
+- `helpers.aggregate_outputs` creates `csv` from SUMO `xml` files with `_parse` functions. New parsers need to be implemented for new types of input files.
+
+
+## Modifications
+- For `vihdintie_trimmed.net.xml`, original location tag was replaced with `<location netOffset="-379248.78,-6676018.56" convBoundary="332.66,824.20,4293.93,6190.00" origBoundary="24.818413,60.203837,24.905479,60.259108" projParameter="+proj=utm +zone=35 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"/>` for correct `pyproj` processing.
+- All edges of Vihdintie network are unnamed.
+
+
+
+
+
+
+
+
+  
+
+

--- a/layout/callbacks.py
+++ b/layout/callbacks.py
@@ -747,12 +747,73 @@ def register_callbacks(app, visualization_mode="edge"):
                         network, variable, timestep_range, timeline_type
                     )
                     heatmap = uh.create_cell_heatmap(heatmap_network, grid, variable)
-                    first_plot = dcc.Graph(
-                        figure=heatmap,
-                        responsive=False,
+                    legend_min = float(heatmap_network[variable].min())
+                    legend_max = float(heatmap_network[variable].max())
+                    if legend_min == legend_max:
+                        legend_padding = abs(legend_min) * 0.01 or 0.01
+                        legend_min -= legend_padding
+                        legend_max += legend_padding
+                    legend_ticks = np.linspace(legend_max, legend_min, 6)
+                    legend = html.Div(
+                        [
+                            html.Div(
+                                uc.UNITS[variable],
+                                style={
+                                    "height": "24px",
+                                    "textAlign": "center",
+                                    "fontSize": "13px",
+                                },
+                            ),
+                            html.Div(
+                                [
+                                    html.Div(
+                                        style={
+                                            "width": "24px",
+                                            "height": "500px",
+                                            "background": (
+                                                "linear-gradient(to bottom, #a50026 0%, "
+                                                "#f46d43 20%, #fee08b 40%, #ffffbf 50%, "
+                                                "#d9ef8b 65%, #66bd63 82%, #006837 100%)"
+                                            ),
+                                        }
+                                    ),
+                                    html.Div(
+                                        [html.Span(f"{tick:.4g}") for tick in legend_ticks],
+                                        style={
+                                            "height": "500px",
+                                            "display": "flex",
+                                            "flexDirection": "column",
+                                            "justifyContent": "space-between",
+                                            "paddingLeft": "8px",
+                                            "fontSize": "12px",
+                                        },
+                                    ),
+                                ],
+                                style={"display": "flex"},
+                            ),
+                        ],
                         style={
+                            "width": "85px",
+                            "marginTop": "115px",
+                            "marginLeft": "12px",
+                            "flex": "0 0 85px",
+                        },
+                    )
+                    first_plot = html.Div(
+                        [
+                            dcc.Graph(
+                                figure=heatmap,
+                                responsive=False,
+                                style={"height": "850px", "width": "800px"},
+                            ),
+                            legend,
+                        ],
+                        style={
+                            "display": "flex",
+                            "alignItems": "flex-start",
+                            "justifyContent": "center",
+                            "width": "900px",
                             "height": "850px",
-                            "width": "800px",
                             "margin": "0 auto",
                             "paddingBottom": "2vh",
                         },

--- a/layout/callbacks.py
+++ b/layout/callbacks.py
@@ -9,7 +9,7 @@ basic_style = {"paddingTop": "2vh", "paddingBottom": "2vh"}
 empty_style = {"display": "none"}
 
 
-def register_callbacks(app):
+def register_callbacks(app, visualization_mode="edge"):
     @app.callback(
         Output("project-info-collapse", "is_open"),
         Input("project-info-button", "n_clicks"),
@@ -85,53 +85,37 @@ def register_callbacks(app):
             Output("situation-div", "style"),
             Output("variable-div", "style"),
             Output("crossfilter-variable", "options"),
-            # Output("timestep-div", "style"),
-            # Output("timeline-div", "style"),
             Output("visualize-button", "style"),
+            Output("crossfilter-situation", "value"),
+            Output("crossfilter-variable", "value"),
+            Output("crossfilter-timestep", "value"),
+            Output("crossfilter-timeline-type", "value"),
         ],
         Input("results-tabs", "value"),
     )
     def show_viz_parameters(tab):
+        defaults = ["baseline", None, 1, "mean"]
         if tab == lc.OBJECTIVES[1]:
             return [
-                basic_style,
-                basic_style,
-                basic_style,
+                basic_style, basic_style, basic_style,
                 uc.TRAFFIC_VARIABLES,
-                # basic_style,
-                # basic_style,
                 {"fontSize": "1.2em"},
+                "baseline", "Mobility flow", 1, "mean",
             ]
         elif tab == lc.OBJECTIVES[2]:
+            aq_default = "AQI" if visualization_mode == "cell" else "Carbon monoxide"
             return [
-                basic_style,
-                basic_style,
-                basic_style,
-                uc.AQ_VARIABLES,
-                # basic_style,
-                # basic_style,
+                basic_style, basic_style, basic_style,
+                (uc.CELL_AQ_VARIABLES if visualization_mode == "cell" else uc.AQ_VARIABLES),
                 {"fontSize": "1.2em"},
+                "baseline", aq_default, 1, "mean",
             ]
         elif tab == lc.OBJECTIVES[3]:
             return [
-                basic_style,
-                basic_style,
-                empty_style,
-                empty_style,
-                # empty_style,
-                # empty_style,
-                {"fontSize": "1.2em"},
+                basic_style, basic_style, empty_style, [],
+                {"fontSize": "1.2em"}, *defaults,
             ]
-        else:
-            return [
-                empty_style,
-                empty_style,
-                empty_style,
-                empty_style,
-                # empty_style,
-                # empty_style,
-                empty_style,
-            ]
+        return [empty_style, empty_style, empty_style, [], empty_style, *defaults]
 
     @app.callback(
         [
@@ -753,6 +737,27 @@ def register_callbacks(app):
                 )
             # AQ variables
             elif tab == lc.OBJECTIVES[2]:
+                if visualization_mode == "cell":
+                    network, grid = uh.get_cell_aq_data(
+                        area=area, season=season, time=time, demand=demand,
+                        optimization=traffic_priority, situation=situation,
+                        variable=variable,
+                    )
+                    heatmap_network = uh.aggregate_cell_aq(
+                        network, variable, timestep_range, timeline_type
+                    )
+                    heatmap = uh.create_cell_heatmap(heatmap_network, grid, variable)
+                    first_plot = dcc.Graph(
+                        figure=heatmap,
+                        responsive=False,
+                        style={
+                            "height": "850px",
+                            "width": "800px",
+                            "margin": "0 auto",
+                            "paddingBottom": "2vh",
+                        },
+                    )
+                    return [first_plot, second_plot, third_plot, fourth_plot, summary_text]
                 # Calculate the data
                 network = uh.get_data(
                     area=area,

--- a/layout/callbacks.py
+++ b/layout/callbacks.py
@@ -103,7 +103,7 @@ def register_callbacks(app, visualization_mode="edge"):
                 "baseline", "Mobility flow", 1, "mean",
             ]
         elif tab == lc.OBJECTIVES[2]:
-            aq_default = "AQI" if visualization_mode == "cell" else "Carbon monoxide"
+            aq_default = "cnc_PM2_5" if visualization_mode == "cell" else "Carbon monoxide"
             return [
                 basic_style, basic_style, basic_style,
                 (uc.CELL_AQ_VARIABLES if visualization_mode == "cell" else uc.AQ_VARIABLES),

--- a/layout/components.py
+++ b/layout/components.py
@@ -230,7 +230,8 @@ simulation_area_col = dbc.Col(
             dcc.Dropdown(
                 options=AREAS,
                 # placeholder="Select area...",
-                value=AREAS[2]["value"],
+                # value=AREAS[2]["value"],
+                value="vihdintie",
                 id="crossfilter-area",
                 optionHeight=50,
                 style={"fontSize": "1.1em"},

--- a/new_app.py
+++ b/new_app.py
@@ -1,32 +1,45 @@
-# %%
-# Imports
+import argparse
+
 from dash import Dash
 import dash_bootstrap_components as dbc
 from layout.components import app_layout
 from layout.callbacks import register_callbacks
 
-# Initialize the app
-app = Dash(
-    __name__,
-    external_stylesheets=[dbc.themes.BOOTSTRAP, dbc.icons.BOOTSTRAP],
-    suppress_callback_exceptions=True,
-    meta_tags=[
-        {"name": "viewport", "content": "width=device-width, initial-scale=1"},
-    ],
-)
 
-# Set the server
+def create_app(visualization_mode="edge"):
+    app = Dash(
+        __name__,
+        external_stylesheets=[dbc.themes.BOOTSTRAP, dbc.icons.BOOTSTRAP],
+        suppress_callback_exceptions=True,
+        meta_tags=[
+            {"name": "viewport", "content": "width=device-width, initial-scale=1"},
+        ],
+    )
+    app.layout = app_layout()
+    register_callbacks(app, visualization_mode=visualization_mode)
+    app.title = "AIOSut"
+    return app
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(description="Run the AioSUT visualization app.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--edge", action="store_const", const="edge", dest="mode",
+        help="visualize air quality per road edge (default)",
+    )
+    mode.add_argument(
+        "--cell", action="store_const", const="cell", dest="mode",
+        help="visualize air quality using AQ grid cells",
+    )
+    parser.set_defaults(mode="edge")
+    return parser.parse_args(args)
+
+
+app = create_app()
 server = app.server
 
-# Set the app layout
-app.layout = app_layout()
 
-# Register callbacks
-register_callbacks(app)
-
-# Set the page title
-app.title = "AIOSut"
-
-# Run the app
 if __name__ == "__main__":
-    app.run(debug=True)
+    cli_args = parse_args()
+    create_app(cli_args.mode).run(debug=True)

--- a/simulation/AQ_units.txt
+++ b/simulation/AQ_units.txt
@@ -1,0 +1,10 @@
+observable_units = [
+    ("AQI",         "1"),          # dimensionless air-quality index, scale 1–5
+    ("cnc_PM2_5",   "µg/m³"),
+    ("cnc_PM10",    "µg/m³"),
+    ("cnc_NO2_gas", "µg/m³"),
+    ("cnc_O3_gas",  "µg/m³"),
+    ("cnc_CO_gas",  "µg/m³"),
+    ("cnc_BC",      "µg/m³"),
+    ("LDSA",        "µm²/cm³"),
+]

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -52,7 +52,7 @@ AREAS = [
     {"label": "Arabia", "value": "arabia", "disabled": True},
     {"label": "Jätkäsaari", "value": "high", "disabled": True},
     {"label": "Kamppi", "value": "kamppi"},
-    {"label": "Vihdintie", "value": "vihdintie", "disabled": True},
+    {"label": "Vihdintie", "value": "vihdintie"},
 ]
 TIMELINE_FUNCTIONS = [
     {"label": "Average", "value": "mean"},

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -102,7 +102,7 @@ UNITS = {
     "Nitrogen oxides": "mg",
     "Respirable particles": "µg",
     "Fine particles": "µg",
-    "AQI": "1",
+    "AQI": "",
     "cnc_PM2_5": "µg/m³",
     "cnc_PM10": "µg/m³",
     "cnc_NO2_gas": "µg/m³",

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -66,6 +66,13 @@ AQ_VARIABLES = [
     {"label": "Respirable particles", "value": "Respirable particles"},
     {"label": "Fine particles", "value": "Fine particles", "disabled": True},
 ]
+CELL_AQ_VARIABLES = [
+    {"label": variable, "value": variable}
+    for variable in (
+        "AQI", "cnc_PM2_5", "cnc_PM10", "cnc_NO2_gas",
+        "cnc_O3_gas", "cnc_CO_gas", "cnc_BC", "LDSA",
+    )
+]
 TRAFFIC_VARIABLES = [
     {"label": "Mobility flow", "value": "Mobility flow"},
     {"label": "Speed", "value": "Speed"},
@@ -95,6 +102,14 @@ UNITS = {
     "Nitrogen oxides": "mg",
     "Respirable particles": "µg",
     "Fine particles": "µg",
+    "AQI": "1",
+    "cnc_PM2_5": "µg/m³",
+    "cnc_PM10": "µg/m³",
+    "cnc_NO2_gas": "µg/m³",
+    "cnc_O3_gas": "µg/m³",
+    "cnc_CO_gas": "µg/m³",
+    "cnc_BC": "µg/m³",
+    "LDSA": "µm²/cm³",
 }
 
 # From variable-situation-to-dataset-columns mapping for filtering

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -796,20 +796,30 @@ def aggregate_outputs(
     net_df = _parse_net_xml(net_path)
     xml_output_files = glob.glob(f"{full_output_folder}/*.xml")
     print(f"Found {len(xml_output_files)} XML output files in {full_output_folder}.")
+
+    output_names = {
+        "edge_noise": "edge_noise_results",
+        "emission": "emission_results",
+        "trip": "trip_results",
+    }
+
+
     for filename in xml_output_files:
         print(f"Processing {filename}...")
         file_without_extension = filename.split(".")[0]
 
         if "edge_noise" in filename:
             result = _parse_edge_noise_xml(filename, net_df)
-        elif "trip" in filename:
-            result = _parse_trip_output_xml(filename)
+            output_name = output_names["edge_noise"]
         elif "emission" in filename:
             result = _parse_emissions_xml(filename, net_df)
+            output_name = output_names["emission"]
+        elif "trip" in filename:
+            result = _parse_trip_output_xml(filename)
+            output_name = output_names["trip"]
         else:
             continue
 
-        output_name = os.path.splitext(os.path.basename(filename))[0]
         csv_path = os.path.join(full_output_folder, f"{output_name}.csv")
 
         result.to_csv(csv_path, index=False)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -289,13 +289,18 @@ def create_cell_heatmap(network, grid, variable):
     # button advance the same frames used by manual slider selection.
     if figure.layout.updatemenus and figure.frames:
         play_button = figure.layout.updatemenus[0].buttons[0]
-        play_frames = list(figure.frames[::3])
-        if play_frames[-1].name != figure.frames[-1].name:
-            play_frames.append(figure.frames[-1])
+        if len(figure.frames) <= 4:
+            play_frames = list(figure.frames)
+            frame_duration = 1000
+        else:
+            play_frames = list(figure.frames[::3])
+            if play_frames[-1].name != figure.frames[-1].name:
+                play_frames.append(figure.frames[-1])
+            frame_duration = 750
         play_button.args = [
             [frame.name for frame in play_frames],
             {
-                "frame": {"duration": 750, "redraw": True},
+                "frame": {"duration": frame_duration, "redraw": True},
                 "mode": "afterall",
                 "fromcurrent": False,
                 "transition": {"duration": 0},

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -87,7 +87,7 @@ def normalize_range(array, x, y):
 
 # Helper function to read data
 def read_data(path):
-    data = pd.read_csv(f"{path}", index_col=0)
+    data = pd.read_csv(f"{path}")
     data = data.loc[:, ~data.columns.str.match(r"^Unnamed")]
 
     data = data.infer_objects()

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 import gzip
 import traci
 import shutil
+import json
 
 # Hover layout
 hover_layout = dict(bgcolor="white", font_size=16)
@@ -168,6 +169,110 @@ def get_data(
         )
     return dataset
 
+
+def get_cell_aq_data(
+    area="kamppi", demand="regular", season="summer", time="weekday",
+    situation="baseline", optimization=0, variable="AQI",
+):
+    """Load minute-resolution air-quality values and their cell geometry."""
+    scenario_dir = os.path.join(
+        "simulation", "scenarios", area.lower(),
+        f"{demand.lower()}_{season.lower()}_{time.lower()}",
+    )
+    result_dir = situation.lower()
+    if result_dir == "optimized":
+        result_dir += f"_{uc.OPTIMIZATION_SLIDER_VALUES[optimization]}"
+    csv_path = os.path.join(scenario_dir, result_dir, "emission_results_cells.csv")
+    if not os.path.exists(csv_path) and os.path.exists(csv_path + ".gz"):
+        csv_path += ".gz"
+    data = read_data(csv_path)
+    required = {"time", "cell_id", variable}
+    missing = required.difference(data.columns)
+    if missing:
+        raise ValueError(f"Missing columns in {csv_path}: {', '.join(sorted(missing))}")
+
+    # Only the minute component matters: 08:58 and 00:58 both map to minute 58.
+    parsed_time = pd.to_datetime(data["time"], errors="raise")
+    data = data[["cell_id", variable]].copy()
+    data["Minute"] = parsed_time.dt.minute
+
+    grid_candidates = [
+        os.path.join(scenario_dir, "AQ_grid.geojson"),
+        os.path.join("simulation", "scenarios", area.lower(), "AQ_grid.geojson"),
+    ]
+    grid_path = next((path for path in grid_candidates if os.path.exists(path)), None)
+    if grid_path is None:
+        raise FileNotFoundError("AQ_grid.geojson not found in the scenario or area folder")
+    with open(grid_path, encoding="utf-8") as grid_file:
+        grid = json.load(grid_file)
+    return data, grid
+
+
+def aggregate_cell_aq(data, variable, timestep_range, aggregation):
+    """Aggregate cells into minute, quarter, half-hour, or hour bins."""
+    data = data.copy()
+    data["Timestep"] = (data["Minute"] // timestep_range + 1) * timestep_range
+    return (
+        data.groupby(["Timestep", "cell_id"], observed=False)[variable]
+        .agg(aggregation)
+        .reset_index()
+    )
+
+
+def create_cell_heatmap(network, grid, variable):
+    """Create an animated polygon heatmap using Plotly's native controls."""
+    color_min = network[variable].min()
+    color_max = network[variable].max()
+    figure = px.choropleth_map(
+        network,
+        geojson=grid,
+        locations="cell_id",
+        featureidkey="properties.cell_id",
+        color=variable,
+        animation_frame="Timestep",
+        animation_group="cell_id",
+        map_style="open-street-map",
+        opacity=0.8,
+        color_continuous_scale="RdYlGn_r",
+        range_color=(color_min, color_max),
+        labels={variable: uc.UNITS[variable], "cell_id": "Cell"},
+        title=f"{variable} cell heatmap",
+    )
+    points = [point for feature in grid["features"]
+              for ring in feature["geometry"]["coordinates"] for point in ring]
+    west, east = min(p[0] for p in points), max(p[0] for p in points)
+    south, north = min(p[1] for p in points), max(p[1] for p in points)
+    figure.update_layout(
+        map={
+            "center": {"lon": (west + east) / 2, "lat": (south + north) / 2},
+            "zoom": 12.0,
+        },
+        width=800,
+        height=850,
+        autosize=False,
+        margin={"l": 0, "r": 0, "t": 50, "b": 0},
+        title_x=0.5,
+        map_uirevision="cell-aq",
+    )
+    figure.update_coloraxes(
+        colorbar_title_text=uc.UNITS[variable],
+        colorbar_len=0.72,
+        colorbar_thickness=24,
+    )
+
+    # Plotly requires full redraws for choropleth/map animation frames. Preserve
+    # its native controls and change only the frame options they generated.
+    if figure.layout.updatemenus:
+        for button in figure.layout.updatemenus[0].buttons:
+            if button.method == "animate" and button.args and button.args[0] is None:
+                button.args[1]["frame"] = {"duration": 600, "redraw": True}
+                button.args[1]["fromcurrent"] = True
+                button.args[1]["transition"] = {"duration": 0}
+    if figure.layout.sliders:
+        for step in figure.layout.sliders[0].steps:
+            step.args[1]["frame"] = {"duration": 0, "redraw": True}
+            step.args[1]["transition"] = {"duration": 0}
+    return figure
 
 def create_heatmap(network, variable):
     """Creates an animated heatmap for with a capability to drilldown on a specific point."""

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -88,6 +88,8 @@ def normalize_range(array, x, y):
 # Helper function to read data
 def read_data(path):
     data = pd.read_csv(f"{path}", index_col=0)
+    data = data.loc[:, ~data.columns.str.match(r"^Unnamed")]
+
     data = data.infer_objects()
     if "Mobility mode" in data.columns:
         data["Mobility mode"] = pd.Categorical(data["Mobility mode"], ordered=True)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -221,8 +221,8 @@ def aggregate_cell_aq(data, variable, timestep_range, aggregation):
 
 def create_cell_heatmap(network, grid, variable):
     """Create an animated polygon heatmap using Plotly's native controls."""
-    color_min = network[variable].min()
-    color_max = network[variable].max()
+    color_min = float(network[variable].min())
+    color_max = float(network[variable].max())
     figure = px.choropleth_map(
         network,
         geojson=grid,
@@ -254,24 +254,77 @@ def create_cell_heatmap(network, grid, variable):
         title_x=0.5,
         map_uirevision="cell-aq",
     )
+    # Lock the full-hour color axis and its tick grid. Explicit cmin/cmax and
+    # tick values prevent frame redraws from recalculating the legend geometry.
+    if color_min == color_max:
+        padding = abs(color_min) * 0.01 or 0.01
+        color_min -= padding
+        color_max += padding
+    color_ticks = np.linspace(color_min, color_max, 6)
     figure.update_coloraxes(
+        cmin=color_min,
+        cmax=color_max,
+        cauto=False,
         colorbar_title_text=uc.UNITS[variable],
         colorbar_len=0.72,
         colorbar_thickness=24,
+        colorbar_tickmode="array",
+        colorbar_tickvals=color_ticks.tolist(),
+        colorbar_ticktext=[f"{value:.4g}" for value in color_ticks],
+        colorbar_x=1.0,
+        colorbar_xanchor="right",
+        colorbar_y=0.5,
+        colorbar_yanchor="middle",
+        showscale=False,
     )
 
-    # Plotly requires full redraws for choropleth/map animation frames. Preserve
-    # its native controls and change only the frame options they generated.
-    if figure.layout.updatemenus:
-        for button in figure.layout.updatemenus[0].buttons:
-            if button.method == "animate" and button.args and button.args[0] is None:
-                button.args[1]["frame"] = {"duration": 600, "redraw": True}
-                button.args[1]["fromcurrent"] = True
-                button.args[1]["transition"] = {"duration": 0}
+    # The legend is rendered outside this figure so it is never part of a map
+    # frame redraw. Hide it in both the initial trace and every frame.
+    figure.update_traces(showscale=False)
+    for frame in figure.frames:
+        for trace in frame.data:
+            trace.showscale = False
+
+    # Map traces need full redraws. Enumerating frame names makes the native Play
+    # button advance the same frames used by manual slider selection.
+    if figure.layout.updatemenus and figure.frames:
+        play_button = figure.layout.updatemenus[0].buttons[0]
+        play_frames = list(figure.frames[::3])
+        if play_frames[-1].name != figure.frames[-1].name:
+            play_frames.append(figure.frames[-1])
+        play_button.args = [
+            [frame.name for frame in play_frames],
+            {
+                "frame": {"duration": 750, "redraw": True},
+                "mode": "afterall",
+                "fromcurrent": False,
+                "transition": {"duration": 0},
+            },
+        ]
     if figure.layout.sliders:
-        for step in figure.layout.sliders[0].steps:
+        slider = figure.layout.sliders[0]
+        slider.update(
+            x=0.12,
+            len=0.82,
+            xanchor="left",
+            pad={"t": 45, "b": 10},
+            currentvalue={
+                "prefix": "Time (in minutes): ",
+                "visible": True,
+                "xanchor": "left",
+                "font": {"size": 14},
+            },
+            font={"size": 11},
+        )
+        for step in slider.steps:
             step.args[1]["frame"] = {"duration": 0, "redraw": True}
             step.args[1]["transition"] = {"duration": 0}
+    if figure.layout.updatemenus:
+        figure.layout.updatemenus[0].update(
+            x=0.02,
+            xanchor="left",
+            pad={"t": 45, "r": 8},
+        )
     return figure
 
 def create_heatmap(network, variable):

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -252,7 +252,6 @@ def create_cell_heatmap(network, grid, variable):
         autosize=False,
         margin={"l": 0, "r": 0, "t": 50, "b": 0},
         title_x=0.5,
-        map_uirevision="cell-aq",
     )
     # Lock the full-hour color axis and its tick grid. Explicit cmin/cmax and
     # tick values prevent frame redraws from recalculating the legend geometry.


### PR DESCRIPTION
Fixed #47 

This pull request:
- add cell visualization mode for AQ (```python -m new_app --cell```).
- cell visualization mode uses ```%scenario_name/AQ_grid.geojson``` (cell polygon borders) and ```emission_results_cells.csv```.
- ```emission_results_cells.csv``` contains selected AQ observables compatible with FMI-Enfuser model outputs (1 hour, cell-based, 1-minute resolution).
- visualization fixes: default map scale changed; color legend moved outside of the plot and is not redrawn; increased latencies for time slider; for 1-minute resolution slider moves every 3 minutes to support 750ms latency.
- defaults for cell mode are set to "baseline", "cnc_PM_2_5", "minutes", "average".